### PR TITLE
Wip/refs

### DIFF
--- a/src/tsx/About.tsx
+++ b/src/tsx/About.tsx
@@ -10,9 +10,6 @@ import { OnClickProp, Page } from "./App";
 const About: React.FC<OnClickProp> = ({ onClickLink, innerRef }) => {
   useEffect(() => {
     document.title = "Abhishek Chaudhuri - About";
-    document.querySelector(".links-about")?.classList.add("active");
-    document.querySelector(".links-projects")?.classList.remove("active");
-    document.querySelector(".links-contact")?.classList.remove("active");
   }, []);
 
   // Forward slashes (\) prevent all the newlines from being rendered

--- a/src/tsx/App.tsx
+++ b/src/tsx/App.tsx
@@ -79,12 +79,6 @@ const App: React.FC = () => {
     }
   }, [location]);
 
-  const htmlDecode = (input: string): string | null => {
-    // Unescape HTML characters (https://stackoverflow.com/a/34064434)
-    const doc: Document = new DOMParser().parseFromString(input, "text/html");
-    return doc.documentElement.textContent;
-  };
-
   const changeTransition = (dest: Page) => {
     const source: string = location.pathname;
 
@@ -122,7 +116,7 @@ const App: React.FC = () => {
           htmlFor="theme-switch"
           aria-label={isDarkMode ? "dark mode on" : "dark mode off"}
         >
-          {isDarkMode ? htmlDecode("&#x1F31C;") : htmlDecode("&#x1F31E;")}
+          {isDarkMode ? "🌜" : "🌞"}
         </FormCheck.Label>
         <FormCheck.Input
           type="checkbox"

--- a/src/tsx/App.tsx
+++ b/src/tsx/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, createRef } from "react";
+import React, { useState, useEffect, createRef, useRef } from "react";
 import { Button, ButtonGroup, Form, FormCheck } from "react-bootstrap";
 import { LinkContainer } from "react-router-bootstrap";
 import { Route, Routes, useLocation } from "react-router-dom";
@@ -43,20 +43,25 @@ const App: React.FC = () => {
   const nodeRef = createRef<HTMLDivElement>(); // removes the need for CSSTransition to call findDOMNode
   const location = useLocation();
 
+  // DOM elements
+  const navbar = useRef<HTMLDivElement>(null);
+  const linkAbout = useRef<HTMLButtonElement>(null);
+  const linkProjects = useRef<HTMLButtonElement>(null);
+  const linkContact = useRef<HTMLButtonElement>(null);
+
   useEffect(() => {
-    let navbar: HTMLElement | null = document.querySelector(".links");
-    if (navbar === null) return;
-    let navPosition: number = navbar.offsetTop;
+    if (navbar.current === null) return;
+    let navPosition: number = navbar.current.offsetTop;
 
     window.onscroll = () => {
       // If the scroll position is beyond the navbar, make it sticky
-      navbar = document.querySelector(".links");
-      if (navbar === null) return;
+      if (navbar.current === null) return;
       // Don't set navPosition to 0
-      navPosition = navbar.offsetTop === 0 ? navPosition : navbar.offsetTop;
+      navPosition =
+        navbar.current.offsetTop === 0 ? navPosition : navbar.current.offsetTop;
       window.pageYOffset >= navPosition
-        ? navbar.classList.add("sticky")
-        : navbar.classList.remove("sticky");
+        ? navbar.current.classList.add("sticky")
+        : navbar.current.classList.remove("sticky");
     };
   }, []); // only componentDidMount()
 
@@ -131,13 +136,19 @@ const App: React.FC = () => {
           Software Engineer | Always Learning and Growing
         </h2>
       </header>
-      <ButtonGroup as="nav" className="links container-fluid">
+      <ButtonGroup as="nav" className="links container-fluid" ref={navbar}>
         {/* Redirect routes without reloading the browser */}
         <LinkContainer to="about">
           <Button
             variant="danger"
             className="links-about"
-            onClick={() => changeTransition(Page.About)}
+            ref={linkAbout}
+            onClick={() => {
+              changeTransition(Page.About);
+              linkAbout.current?.classList.add("active");
+              linkProjects.current?.classList.remove("active");
+              linkContact.current?.classList.remove("active");
+            }}
           >
             About
           </Button>
@@ -146,7 +157,13 @@ const App: React.FC = () => {
           <Button
             variant="warning"
             className="links-projects"
-            onClick={() => changeTransition(Page.Projects)}
+            ref={linkProjects}
+            onClick={() => {
+              changeTransition(Page.Projects);
+              linkAbout.current?.classList.remove("active");
+              linkProjects.current?.classList.add("active");
+              linkContact.current?.classList.remove("active");
+            }}
           >
             Projects
           </Button>
@@ -155,7 +172,13 @@ const App: React.FC = () => {
           <Button
             variant="success"
             className="links-contact"
-            onClick={() => changeTransition(Page.Contact)}
+            ref={linkContact}
+            onClick={() => {
+              changeTransition(Page.Contact);
+              linkAbout.current?.classList.remove("active");
+              linkProjects.current?.classList.remove("active");
+              linkContact.current?.classList.add("active");
+            }}
           >
             Contact
           </Button>

--- a/src/tsx/Contact.tsx
+++ b/src/tsx/Contact.tsx
@@ -19,9 +19,6 @@ const Contact: React.FC<ContactProps> = ({
 }) => {
   useEffect(() => {
     document.title = "Abhishek Chaudhuri - Contact";
-    document.querySelector(".links-about")?.classList.remove("active");
-    document.querySelector(".links-projects")?.classList.remove("active");
-    document.querySelector(".links-contact")?.classList.add("active");
   }, []);
 
   return (

--- a/src/tsx/Projects.tsx
+++ b/src/tsx/Projects.tsx
@@ -48,9 +48,6 @@ const Projects: React.FC<ProjectsProps> = ({
 
   useEffect(() => {
     document.title = "Abhishek Chaudhuri - Projects";
-    document.querySelector(".links-about")?.classList.remove("active");
-    document.querySelector(".links-projects")?.classList.add("active");
-    document.querySelector(".links-contact")?.classList.remove("active");
 
     // Hide the scrolling buttons if possible on startup
     for (const list of projectsListRef.current) {


### PR DESCRIPTION
## Proposed Changes

- Use `useRef()` instead of `document.querySelector` to take better advantage of React
- Use 🌞 and 🌜 instead of their encoded counterparts (CodeQL will confirm if this is a security concern)
