### PR TITLE
Replace Node 14 with 20

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
## Proposed Changes

- Since Node 14 is [end-of-life](https://endoflife.date/nodejs) and Node 20 was just released, I edited the Node versions we're testing on.